### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-python-dotenv>=0.21.0 
-aiogram>=3.0.0
 telethon>=1.34.0
 openai>=1.0.0 
 aiohttp>=3.8.0 
@@ -7,7 +5,6 @@ httpx>=0.23.0
 requests>=2.28.0 
 beautifulsoup4>=4.11.0 
 pydub>=0.25.0 
-uvicorn>=0.18.0 
 pypdf>=3.0.0 
 pinecone>=2.0.0 
 tenacity>=8.0.0 


### PR DESCRIPTION
## Summary
- drop unused aiogram, python-dotenv and uvicorn dependencies

## Testing
- `pytest -q`
- `flake8` *(fails: E221 multiple spaces before operator, E302 expected 2 blank lines, E501 line too long, F541 f-string is missing placeholders, F824 `global current_key_idx` is unused, F401 'asyncio' imported but unused, W291 trailing whitespace, W391 blank line at end of file)*

------
https://chatgpt.com/codex/tasks/task_e_68919b12cb148329bd50bad2907d1731