### PR TITLE
feat: validate API keys at startup

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -19,13 +19,23 @@ from utils.deepseek_search import DEEPSEEK_ENABLED
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    logger.error("OPENAI_API_KEY environment variable is not set")
+    raise SystemExit("Missing OPENAI_API_KEY. Set the environment variable and restart the application.")
+
+DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY")
+if not DEEPSEEK_API_KEY:
+    logger.error("DEEPSEEK_API_KEY environment variable is not set")
+    raise SystemExit("Missing DEEPSEEK_API_KEY. Set the environment variable and restart the application.")
+
 API_ID = int(os.getenv("TELEGRAM_API_ID", 20973755))
 API_HASH = os.getenv("TELEGRAM_API_HASH", "51173cd91874b5f7576b2012f08f40f0")
 PHONE = os.getenv("TELEGRAM_PHONE", "+972584038033")
 
 client = TelegramClient("arianna", API_ID, API_HASH)
 engine = AriannaEngine()
-openai_client = openai.AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+openai_client = openai.AsyncOpenAI(api_key=OPENAI_API_KEY)
 DEEPSEEK_CMD = "/ds"
 SEARCH_CMD = "/search"
 INDEX_CMD = "/index"

--- a/utils/arianna_engine.py
+++ b/utils/arianna_engine.py
@@ -18,6 +18,11 @@ class AriannaEngine:
     def __init__(self):
         self.logger = logging.getLogger(__name__)
         self.openai_key = os.getenv("OPENAI_API_KEY")
+        if not self.openai_key:
+            raise SystemExit("OPENAI_API_KEY environment variable is not set. Exiting.")
+        self.deepseek_key = os.getenv("DEEPSEEK_API_KEY")
+        if not self.deepseek_key:
+            raise SystemExit("DEEPSEEK_API_KEY environment variable is not set. Exiting.")
         self.headers    = {
             "Authorization": f"Bearer {self.openai_key}",
             "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- ensure `OPENAI_API_KEY` and `DEEPSEEK_API_KEY` are present before starting
- abort application with clear message when API keys are missing

## Testing
- `pytest`
- `flake8 server_arianna.py utils/arianna_engine.py` *(fails: E501 line too long, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68919b3f5c108329ad806f7d381ccc23