### PR TITLE
Handle request timeouts

### DIFF
--- a/utils/arianna_engine.py
+++ b/utils/arianna_engine.py
@@ -23,8 +23,8 @@ class AriannaEngine:
             "Content-Type": "application/json",
             "OpenAI-Beta": "assistants=v2"
         }
-        # Allow customization of request timeouts; None disables timeouts
-        self.request_timeout = None
+        # Timeout (in seconds) for all HTTP requests
+        self.request_timeout = 30
         self.assistant_id = None
         self.threads      = load_threads()  # user_id → thread_id
 


### PR DESCRIPTION
## Summary
- set default HTTP request timeout to 30 seconds
- catch `httpx.TimeoutException` in follow-up and message handlers and reply with a friendly error

## Testing
- `pytest`
- `flake8` *(fails: multiple style violations)*

------
https://chatgpt.com/codex/tasks/task_e_68919b532c5083299b2f619bd9b7233d