### PR TITLE
Use logging for prompt diagnostics

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -17,7 +17,11 @@ from utils.vector_store import semantic_search, vectorize_all_files
 from utils.text_helpers import extract_text_from_url
 from utils.deepseek_search import DEEPSEEK_ENABLED
 
-logging.basicConfig(level=logging.INFO)
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -264,7 +268,7 @@ async def main():
     except Exception:
         logger.exception("Assistant initialization failed")
         return
-    print("🚀 Arianna client started")
+    logger.info("🚀 Arianna client started")
     await client.run_until_disconnected()
 
 if __name__ == "__main__":

--- a/utils/genesis.py
+++ b/utils/genesis.py
@@ -4,6 +4,7 @@ import random
 import datetime
 import requests
 import os
+import logging
 
 # === Настройки и переменные из окружения / .env ===
 GROUP_ID = os.environ.get("GROUP_ID", "ARIANNA-CORE")
@@ -12,6 +13,8 @@ PINECONE_API_KEY = os.environ.get("PINECONE_API_KEY")
 PINECONE_INDEX = os.environ.get("PINECONE_INDEX")
 CHRONICLE_PATH = os.environ.get("CHRONICLE_PATH", "./config/chronicle.log")
 TELEGRAM_TOKEN = os.environ.get("TELEGRAM_TOKEN")
+
+logger = logging.getLogger(__name__)
 
 # — Темы для поиска
 SEARCH_TOPICS = [
@@ -283,7 +286,7 @@ class AriannaGenesis:
             self._log(f"[AriannaGenesis] log_resonance error: {e}")
 
     def _log(self, msg):
-        print(msg)
+        logger.info(msg)
         try:
             with open(self.chronicle_path, "a", encoding="utf-8") as f:
                 f.write(f"{datetime.datetime.now().isoformat()} {msg}\n")

--- a/utils/prompt.py
+++ b/utils/prompt.py
@@ -1,4 +1,8 @@
+import logging
 import tiktoken
+
+
+logger = logging.getLogger(__name__)
 
 # ────────────────────────────────────────────────────────────────────────────────
 # SYSTEM / AGENT PROMPT FOR ARIANNA (ANCHOR PROTOCOL v7.0, Monday-compatible)
@@ -98,6 +102,6 @@ def build_system_prompt(
         full_prompt = enc.decode(tokens[:MAX_TOKENS])
 
     # (For debug)
-    print("=== ARIANNA ANCHOR SYSTEM PROMPT ===")
-    print(full_prompt[:1000])
+    logger.debug("=== ARIANNA ANCHOR SYSTEM PROMPT ===")
+    logger.debug(full_prompt[:1000])
     return full_prompt


### PR DESCRIPTION
## Summary
- switch prompt and server debug prints to structured logging
- route AriannaGenesis logs through logging module
- centralize logging config with optional LOG_LEVEL env var

## Testing
- `flake8 --max-line-length=500 --extend-ignore=E221,E261,E302,E306 utils/prompt.py utils/genesis.py server_arianna.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68919e57440083298a070b9178822c40