### PR TITLE
Use file locking for thread store

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Unless you implement persistent storage, this memory resets each time the
 server restarts. Set `DEEPSEEK_API_KEY` in your environment to activate the
 DeepSeek integration before launching the bot.
 
+Thread ID mappings are written to `data/threads.json` with a file lock so
+concurrent processes do not corrupt the file. For better durability—especially
+before introducing client-id‑based multi-user flows—consider migrating this
+store to a lightweight database such as SQLite.
+
 ### Group chat behavior
 
 When used in a group, Arianna responds only when you address her explicitly or when you reply to one of her messages. The following triggers are recognized:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 telethon>=1.34.0
-openai>=1.0.0 
-aiohttp>=3.8.0 
-httpx>=0.23.0 
-requests>=2.28.0 
-beautifulsoup4>=4.11.0 
+openai>=1.0.0
+filelock>=3.0.0
+aiohttp>=3.8.0
+httpx>=0.23.0
+requests>=2.28.0
+beautifulsoup4>=4.11.0
 pydub>=0.25.0 
 pypdf>=3.0.0 
 pinecone>=2.0.0 

--- a/utils/thread_store.py
+++ b/utils/thread_store.py
@@ -1,25 +1,34 @@
 import os
 import json
+import logging
+from filelock import FileLock
 
 THREADS_PATH = "data/threads.json"
+logger = logging.getLogger(__name__)
+
+# TODO: consider migrating to SQLite for better durability before introducing
+# client-id–based multi-user flows.
 
 
 def load_threads(path: str = THREADS_PATH) -> dict:
     """Load stored thread mappings from JSON."""
-    if os.path.isfile(path):
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                return json.load(f)
-        except Exception:
-            return {}
+    lock = FileLock(f"{path}.lock")
+    try:
+        with lock:
+            if os.path.isfile(path):
+                with open(path, "r", encoding="utf-8") as f:
+                    return json.load(f)
+    except Exception:
+        logger.exception("Failed to load threads from %s", path)
     return {}
 
 
 def save_threads(threads: dict, path: str = THREADS_PATH) -> None:
     """Save thread mappings to JSON."""
+    lock = FileLock(f"{path}.lock")
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
+        with lock, open(path, "w", encoding="utf-8") as f:
             json.dump(threads, f, ensure_ascii=False, indent=2)
     except Exception:
-        pass
+        logger.exception("Failed to save threads to %s", path)


### PR DESCRIPTION
## Summary
- add file locking and error logging to thread storage
- document thread persistence and potential SQLite migration
- include filelock dependency

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68919efad2448329bc258f61ce317f20