### PR TITLE
Fix Telegram client type hints for older Python

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -4,6 +4,7 @@ import asyncio
 import random
 import logging
 import tempfile
+from typing import Optional
 
 import openai
 import httpx
@@ -40,7 +41,7 @@ PHONE = os.getenv("TELEGRAM_PHONE", "+972584038033")
 BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 
 
-def create_telegram_client(phone: str | None = None, bot_token: str | None = None) -> TelegramClient:
+def create_telegram_client(phone: Optional[str] = None, bot_token: Optional[str] = None) -> TelegramClient:
     session_name = "arianna_bot" if bot_token else "arianna"
     return TelegramClient(session_name, API_ID, API_HASH)
 


### PR DESCRIPTION
## Summary
- Use `typing.Optional` instead of PEP604 unions in Telegram client creation for broader Python compatibility

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891a0a6a61c8329a0dd16bc56367ae2