### PR TITLE
fix: support older Python

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -7,6 +7,7 @@ import tempfile
 
 import openai
 import httpx
+from typing import Optional
 from pydub import AudioSegment
 from telethon import TelegramClient, events
 from telethon.tl.types import MessageEntityMention
@@ -40,7 +41,7 @@ PHONE = os.getenv("TELEGRAM_PHONE", "+972584038033")
 BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 
 
-def create_telegram_client(phone: str | None = None, bot_token: str | None = None) -> TelegramClient:
+def create_telegram_client(phone: Optional[str] = None, bot_token: Optional[str] = None) -> TelegramClient:
     session_name = "arianna_bot" if bot_token else "arianna"
     return TelegramClient(session_name, API_ID, API_HASH)
 


### PR DESCRIPTION
## Summary
- import Optional typing and use Optional[...] for Telegram client creation

## Testing
- `pytest -q`
- `flake8 server_arianna.py` *(fails: line too long and other style issues)*
- `python -m py_compile server_arianna.py`


------
https://chatgpt.com/codex/tasks/task_e_6891a0a6a61c8329a0dd16bc56367ae2