### PR TITLE
refactor: centralize bot handler logic

### DIFF
--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -1,0 +1,51 @@
+import sys
+import asyncio
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from utils import bot_handlers as bh  # noqa: E402
+
+
+def test_append_link_snippets(monkeypatch):
+    async def fake_extract(url: str) -> str:
+        assert url == "https://example.com"
+        return "Example content"
+
+    async def run_test():
+        monkeypatch.setattr(bh, "extract_text_from_url", fake_extract)
+        text = "Check https://example.com"
+        result = await bh.append_link_snippets(text)
+        assert "Example content" in result
+        assert text in result
+
+    asyncio.run(run_test())
+
+
+def test_parse_command():
+    cmd, arg = bh.parse_command("/search kittens")
+    assert cmd == bh.SEARCH_CMD
+    assert arg == "kittens"
+
+    cmd, arg = bh.parse_command("/DS data")
+    assert cmd == bh.DEEPSEEK_CMD
+    assert arg == "data"
+
+    cmd, arg = bh.parse_command("no command here")
+    assert cmd is None
+    assert arg == "no command here"
+
+
+def test_dispatch_response_splits():
+    parts = []
+
+    async def run_test():
+        async def sender(part: str) -> None:
+            parts.append(part)
+
+        text = "a" * 5000
+        await bh.dispatch_response(sender, text)
+
+    asyncio.run(run_test())
+    assert len(parts) == 2
+    assert parts[0] == "a" * 4000
+    assert parts[1] == "a" * 1000

--- a/utils/bot_handlers.py
+++ b/utils/bot_handlers.py
@@ -1,0 +1,51 @@
+import os
+import re
+import asyncio
+from typing import Callable, Awaitable, Optional
+
+from utils.split_message import split_message
+from utils.text_helpers import extract_text_from_url
+
+DEEPSEEK_CMD = "/ds"
+SEARCH_CMD = "/search"
+INDEX_CMD = "/index"
+
+URL_REGEX = re.compile(r"https://\S+")
+URL_FETCH_TIMEOUT = int(os.getenv("URL_FETCH_TIMEOUT", 10))
+
+SKIP_SHORT_PROB = float(os.getenv("SKIP_SHORT_PROB", 0.5))
+
+SendFunc = Callable[[str], Awaitable[None]]
+
+
+async def append_link_snippets(text: str) -> str:
+    """Append snippet from any https:// link in the text."""
+    urls = URL_REGEX.findall(text)
+    if not urls:
+        return text
+    tasks = [asyncio.wait_for(extract_text_from_url(url), URL_FETCH_TIMEOUT) for url in urls]
+    snippets = await asyncio.gather(*tasks, return_exceptions=True)
+    parts = [text]
+    for url, snippet in zip(urls, snippets):
+        snippet_text = (
+            f"[Error loading page: {snippet}]" if isinstance(snippet, Exception) else snippet
+        )
+        parts.append(f"\n[Snippet from {url}]\n{snippet_text[:500]}")
+    return "\n".join(parts)
+
+
+def parse_command(text: str) -> tuple[Optional[str], str]:
+    """Return (command, argument) if text starts with a known command."""
+    stripped = text.strip()
+    lowered = stripped.lower()
+    for cmd in (SEARCH_CMD, INDEX_CMD, DEEPSEEK_CMD):
+        if lowered.startswith(cmd):
+            arg = stripped[len(cmd):].lstrip()
+            return cmd, arg
+    return None, stripped
+
+
+async def dispatch_response(send: SendFunc, text: str) -> None:
+    """Split long responses and dispatch each part via send."""
+    for chunk in split_message(text):
+        await send(chunk)


### PR DESCRIPTION
## Summary
- factor link snippet extraction, command parsing, and response dispatch into new `utils.bot_handlers`
- use shared handlers in `server_arianna.py` and `webhook_server.py`
- add tests covering shared handler behaviours

## Testing
- `flake8 utils/bot_handlers.py tests/test_bot_handlers.py --max-line-length 120`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897982ff554832988e151d600a7d0e2