### PR TITLE
Reuse single HTTPX client in AriannaEngine

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -292,9 +292,13 @@ async def main():
         await engine.setup_assistant()
     except Exception:
         logger.exception("Assistant initialization failed")
+        await engine.aclose()
         return
     logger.info("🚀 Arianna client started")
-    await client.run_until_disconnected()
+    try:
+        await client.run_until_disconnected()
+    finally:
+        await engine.aclose()
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/utils/file_handling.py
+++ b/utils/file_handling.py
@@ -15,7 +15,7 @@ def extract_text_from_pdf(path):
         text = text.strip()
         if text:
             return text[:MAX_TEXT_SIZE] + ('\n[Truncated]' if len(text) > MAX_TEXT_SIZE else '')
-        return f'[PDF is empty or unreadable.]'
+        return '[PDF is empty or unreadable.]'
     except Exception as e:
         return f"[Error reading PDF ({os.path.basename(path)}): {e}. Try using a simple TXT file.]"
 

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -89,6 +89,10 @@ async def startup() -> None:
     await engine.setup_assistant()
     logger.info("🚀 Webhook server started")
 
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    await engine.aclose()
+
 @app.get("/")
 async def root() -> dict:
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- Maintain one `httpx.AsyncClient` inside `AriannaEngine`
- Close the shared client from server and webhook shutdown paths
- Fix stray f-string in PDF handler

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6897984ee828832984203e59449d1f75