### PR TITLE
Add test suite and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio flake8
+      - name: Lint
+        run: flake8 utils tests
+      - name: Test
+        run: pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_split_message.py
+++ b/tests/test_split_message.py
@@ -1,0 +1,18 @@
+from utils.split_message import split_message
+
+
+def test_split_message_splits_on_newline():
+    text = "line1\nline2\nline3"
+    result = split_message(text, max_length=10)
+    assert result == ["line1", "line2", "line3"]
+
+
+def test_split_message_handles_long_lines():
+    text = "a" * 25
+    result = split_message(text, max_length=10)
+    assert result == ["a" * 10, "a" * 10, "a" * 5]
+
+
+def test_split_message_empty_returns_placeholder():
+    expected = ["Even emptiness can be divided."]
+    assert split_message("", max_length=10) == expected

--- a/tests/test_text_helpers.py
+++ b/tests/test_text_helpers.py
@@ -1,0 +1,66 @@
+import aiohttp
+import pytest
+
+from utils.text_helpers import extract_text_from_url
+
+
+class MockResponse:
+    def __init__(self, text):
+        self._text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def text(self):
+        return self._text
+
+    def raise_for_status(self):
+        pass
+
+
+class MockSession:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def get(self, url, timeout, headers):
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_extract_text_from_url_success(monkeypatch):
+    html = (
+        "<html><body><script>ignore()</script><p>Hello</p>"
+        "<style>.a{}</style></body></html>"
+    )
+    response = MockResponse(html)
+    monkeypatch.setattr(
+        aiohttp, "ClientSession", lambda: MockSession(response)
+    )
+    text = await extract_text_from_url("http://example.com")
+    assert text == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_extract_text_from_url_error(monkeypatch):
+    class FailingSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, url, timeout, headers):
+            raise Exception("boom")
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: FailingSession())
+    text = await extract_text_from_url("http://example.com")
+    assert text.startswith("[Error loading page:")

--- a/utils/text_helpers.py
+++ b/utils/text_helpers.py
@@ -2,9 +2,11 @@ import difflib
 import aiohttp
 from bs4 import BeautifulSoup
 
+
 def fuzzy_match(a, b):
     """Return similarity ratio between two strings."""
     return difflib.SequenceMatcher(None, a, b).ratio()
+
 
 async def extract_text_from_url(url):
     """Fetches a web page asynchronously and returns visible text."""


### PR DESCRIPTION
## Summary
- configure pytest for the project
- add unit tests for text extraction and message splitting helpers
- run lint and tests in GitHub Actions on each push and PR

## Testing
- `flake8 tests utils/text_helpers.py utils/split_message.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68979aba027c8329b10046774ec1e8ab