### PR TITLE
Log skip reasons and clarify message filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Several optional variables fine‑tune the bot's behavior:
 
 - `GROUP_DELAY_MIN`/`GROUP_DELAY_MAX` – range in seconds to wait before replying in groups (default 120–600).
 - `PRIVATE_DELAY_MIN`/`PRIVATE_DELAY_MAX` – range for private chats (default 30–180).
-- `SKIP_SHORT_PROB` – chance to ignore very short or non‑question messages (default 0.5).
+- `SKIP_SHORT_PROB` – chance to ignore very short or non‑question messages (default 0.5; set to 0 to disable).
 - `FOLLOWUP_PROB` – probability of sending a follow‑up later (default 0.2).
 - `FOLLOWUP_DELAY_MIN`/`FOLLOWUP_DELAY_MAX` – delay range for follow‑ups in seconds (default 900–7200).
 
@@ -141,6 +141,15 @@ the chat type and is configurable via the environment variables listed above.
 Short statements or messages without a question mark are ignored about half of
 the time. Occasionally she will send a brief follow‑up message referencing the
 earlier conversation.
+
+### Why the bot might not respond
+
+The bot intentionally filters some messages:
+
+- In group chats she replies only when mentioned or when you answer one of her messages.
+- Very short texts or those without a question mark are skipped with probability controlled by `SKIP_SHORT_PROB` (default `0.5`).
+  Set `SKIP_SHORT_PROB=0` to disable this random skipping.
+- Voice messages that cannot be transcribed are ignored.
 
 ## Deployment
 

--- a/server_arianna.py
+++ b/server_arianna.py
@@ -199,10 +199,12 @@ async def voice_messages(event):
     text = await transcribe_voice(tmp.name)
     if text.startswith("Sorry, I couldn't transcribe"):
         await event.reply(text)
+        logger.info("Skipping voice message: transcription failed")
         return
     text = await append_link_snippets(text)
     if len(text.split()) < 4 or '?' not in text:
         if random.random() < SKIP_SHORT_PROB:
+            logger.info("Skipping voice message: too short or no question")
             return
     try:
         resp = await engine.ask(thread_key, text, is_group=is_group)
@@ -215,6 +217,7 @@ async def voice_messages(event):
 @client.on(events.NewMessage(incoming=True))
 async def all_messages(event):
     if event.out:
+        logger.info("Ignoring outgoing message")
         return
     user_id = str(event.sender_id)
     text = event.raw_text or ""
@@ -222,6 +225,7 @@ async def all_messages(event):
     cmd, arg = parse_command(text)
     if cmd == SEARCH_CMD:
         if not arg:
+            logger.info("Search command missing argument")
             return
         chunks = await semantic_search(arg, engine.openai_key)
         if not chunks:
@@ -255,6 +259,7 @@ async def all_messages(event):
             await event.reply("DeepSeek integration is not configured")
             return
         if not arg:
+            logger.info("DeepSeek command missing argument")
             return
         resp = await engine.deepseek_reply(arg)
         async def send(part: str) -> None:
@@ -289,10 +294,12 @@ async def all_messages(event):
         mentioned = True
 
     if not (mentioned or is_reply):
+        logger.info("Message ignored: bot not mentioned and not a reply")
         return
 
     if len(text.split()) < 4 or '?' not in text:
         if random.random() < SKIP_SHORT_PROB:
+            logger.info("Skipping message: too short or no question")
             return
 
     thread_key = user_id if not is_group else str(event.chat_id)

--- a/utils/bot_handlers.py
+++ b/utils/bot_handlers.py
@@ -13,7 +13,9 @@ INDEX_CMD = "/index"
 URL_REGEX = re.compile(r"https://\S+")
 URL_FETCH_TIMEOUT = int(os.getenv("URL_FETCH_TIMEOUT", 10))
 
-SKIP_SHORT_PROB = float(os.getenv("SKIP_SHORT_PROB", 0.5))
+# Chance to ignore very short or non-question messages.
+# Set to 0 to disable random skipping.
+SKIP_SHORT_PROB = max(0.0, min(1.0, float(os.getenv("SKIP_SHORT_PROB", 0.5))))
 
 SendFunc = Callable[[str], Awaitable[None]]
 


### PR DESCRIPTION
## Summary
- log reasons when voice or text messages are ignored
- allow disabling random skip with `SKIP_SHORT_PROB` and document filtering behavior

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68979c9aaf9c83299457620caeddbabe