### PR TITLE
Raise errors on assistant setup failure

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -318,10 +318,10 @@ async def main():
     BOT_ID = me.id
     try:
         await engine.setup_assistant()
-    except Exception:
+    except RuntimeError:
         logger.exception("Assistant initialization failed")
         await engine.aclose()
-        return
+        raise SystemExit(1)
     logger.info("🚀 Arianna client started")
     try:
         await client.run_until_disconnected()

--- a/tests/test_webhook_startup_exception.py
+++ b/tests/test_webhook_startup_exception.py
@@ -1,0 +1,42 @@
+import asyncio
+import importlib
+
+import pytest
+
+
+def test_webhook_startup_handles_openai_failure(monkeypatch):
+    """Ensure startup exits when assistant creation fails."""
+
+    # Provide required environment variables before importing the module
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "token")
+    monkeypatch.setenv("OPENAI_API_KEY", "ok")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ok")
+
+    webhook_server = importlib.import_module("webhook_server")
+
+    class DummyResp:
+        def json(self):
+            return {"result": {"username": "bot", "id": 1}}
+
+    class DummyAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def get(self, *args, **kwargs):
+            return DummyResp()
+
+        async def post(self, *args, **kwargs):
+            return DummyResp()
+
+    monkeypatch.setattr(webhook_server.httpx, "AsyncClient", lambda *a, **k: DummyAsyncClient())
+
+    async def fail_setup():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(webhook_server.engine, "setup_assistant", fail_setup)
+
+    with pytest.raises(SystemExit):
+        asyncio.run(webhook_server.startup())

--- a/utils/arianna_engine.py
+++ b/utils/arianna_engine.py
@@ -88,10 +88,10 @@ class AriannaEngine:
             r.raise_for_status()
         except httpx.TimeoutException:
             self.logger.error("OpenAI request timed out during assistant setup")
-            return "OpenAI request timed out. Please try again later."
+            raise RuntimeError("OpenAI request timed out. Please try again later.")
         except Exception as e:
             self.logger.error("Failed to create Arianna Assistant", exc_info=e)
-            return f"Failed to create Arianna Assistant: {e}"
+            raise RuntimeError(f"Failed to create Arianna Assistant: {e}")
 
         self.assistant_id = r.json()["id"]
         self.logger.info(f"✅ Arianna Assistant created: {self.assistant_id}")

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -69,7 +69,12 @@ async def startup() -> None:
                 f"https://api.telegram.org/bot{BOT_TOKEN}/setWebhook",
                 json={"url": webhook_url},
             )
-    await engine.setup_assistant()
+    try:
+        await engine.setup_assistant()
+    except RuntimeError:
+        logger.exception("Assistant initialization failed")
+        await engine.aclose()
+        raise SystemExit(1)
     logger.info("🚀 Webhook server started")
 
 @app.on_event("shutdown")


### PR DESCRIPTION
## Summary
- raise `RuntimeError` from `AriannaEngine.setup_assistant` when API calls fail
- exit both CLI and webhook servers if assistant initialization fails
- test webhook startup failure handling

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68979cb99a6083299a1b1fe72417a6e1