### PR TITLE
Use dedicated RNG for Genesis scheduler

### DIFF
--- a/utils/genesis.py
+++ b/utils/genesis.py
@@ -81,6 +81,7 @@ class AriannaGenesis:
         self._date_last_run = None
         self._running = False
         self._task = None
+        self._rng = random.Random()
 
     async def run(self):
         """
@@ -125,10 +126,10 @@ class AriannaGenesis:
 
     def _random_time_between(self, now, hour_start, hour_end):
         seed = int(now.strftime('%Y%m%d')) + hour_start + hour_end
-        random.seed(seed)
-        h = random.randint(hour_start, hour_end)
-        m = random.randint(0, 59)
-        s = random.randint(0, 59)
+        self._rng.seed(seed)
+        h = self._rng.randint(hour_start, hour_end)
+        m = self._rng.randint(0, 59)
+        s = self._rng.randint(0, 59)
         return now.replace(hour=h, minute=m, second=s, microsecond=0)
 
     async def _sleep_until_next_day(self):


### PR DESCRIPTION
## Summary
- add per-instance RNG to `AriannaGenesis`
- use `self._rng` for deterministic schedule times without affecting global random state

## Testing
- `ruff check utils/genesis.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68979cc5ba188329a9622b79766e7027