### PR TITLE
Add /help command for Telegram bot

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -83,7 +83,16 @@ engine = AriannaEngine()
 openai_client = openai.AsyncOpenAI(api_key=OPENAI_API_KEY)
 VOICE_ON_CMD = "/voiceon"
 VOICE_OFF_CMD = "/voiceoff"
+HELP_CMD = "/help"
 VOICE_ENABLED = {}
+HELP_TEXT = (
+    f"{SEARCH_CMD} <query> - semantic search documents\n"
+    f"{INDEX_CMD} - index documents\n"
+    f"{DEEPSEEK_CMD} <query> - ask DeepSeek\n"
+    f"{VOICE_ON_CMD} - enable voice responses\n"
+    f"{VOICE_OFF_CMD} - disable voice responses\n"
+    f"{HELP_CMD} - show this help message"
+)
 
 # --- optional behavior tuning ---
 GROUP_DELAY_MIN   = int(os.getenv("GROUP_DELAY_MIN", 120))   # 2 minutes
@@ -248,6 +257,9 @@ async def all_messages(event):
     if text.strip().lower() == VOICE_OFF_CMD:
         VOICE_ENABLED[event.chat_id] = False
         await event.reply("Voice responses disabled")
+        return
+    if text.strip().lower() == HELP_CMD:
+        await event.reply(HELP_TEXT)
         return
 
     if cmd == DEEPSEEK_CMD:

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -19,6 +19,14 @@ from utils.bot_handlers import (
     SKIP_SHORT_PROB,
 )
 
+HELP_CMD = "/help"
+HELP_TEXT = (
+    f"{SEARCH_CMD} <query> - semantic search documents\n"
+    f"{INDEX_CMD} - index documents\n"
+    f"{DEEPSEEK_CMD} <query> - ask DeepSeek\n"
+    f"{HELP_CMD} - show this help message"
+)
+
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(
     level=getattr(logging, LOG_LEVEL, logging.INFO),
@@ -125,6 +133,10 @@ async def telegram_webhook(request: Request) -> dict:
             async def send(part: str) -> None:
                 await send_message(chat_id, part)
             await dispatch_response(send, resp)
+        return {"ok": True}
+
+    if text.strip().lower() == HELP_CMD:
+        await send_message(chat_id, HELP_TEXT)
         return {"ok": True}
 
     mentioned = False


### PR DESCRIPTION
## Summary
- add `/help` command constant and text
- handle `/help` in both Telethon and webhook servers to list available commands

## Testing
- `ruff check server_arianna.py webhook_server.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68979ce6dc1c8329a3b6cd69f8a66922