### PR TITLE
Handle timeouts and log request text

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -204,11 +204,20 @@ async def voice_messages(event):
     if len(text.split()) < 4 or '?' not in text:
         if random.random() < SKIP_SHORT_PROB:
             return
+    logger.info("Voice message text: %s", text)
     try:
         resp = await engine.ask(thread_key, text, is_group=is_group)
     except httpx.TimeoutException:
-        logger.error("Voice message processing timed out", exc_info=True)
+        logger.error("Voice message processing timed out: %s", text, exc_info=True)
         await event.reply("Request timed out. Please try again later.")
+        return
+    except TimeoutError:
+        logger.error("Voice message processing timeout error: %s", text, exc_info=True)
+        await event.reply("Request timed out. Please try again later.")
+        return
+    except Exception:
+        logger.exception("Voice message processing failed: %s", text)
+        await event.reply("Internal error occurred. Please try again later.")
         return
     asyncio.create_task(send_delayed_response(event, resp, is_group, thread_key))
 
@@ -297,11 +306,20 @@ async def all_messages(event):
 
     thread_key = user_id if not is_group else str(event.chat_id)
     prompt = await append_link_snippets(text)
+    logger.info("Message text: %s", text)
     try:
         resp = await engine.ask(thread_key, prompt, is_group=is_group)
     except httpx.TimeoutException:
-        logger.error("OpenAI request timed out", exc_info=True)
+        logger.error("OpenAI request timed out: %s", text, exc_info=True)
         await event.reply("Request timed out. Please try again later.")
+        return
+    except TimeoutError:
+        logger.error("Timeout error while processing message: %s", text, exc_info=True)
+        await event.reply("Request timed out. Please try again later.")
+        return
+    except Exception:
+        logger.exception("Failed to process message: %s", text)
+        await event.reply("Internal error occurred. Please try again later.")
         return
     asyncio.create_task(send_delayed_response(event, resp, is_group, thread_key))
 


### PR DESCRIPTION
## Summary
- log incoming text in `voice_messages` and `all_messages`
- handle `TimeoutError` and other exceptions with user-facing error replies

## Testing
- `flake8 server_arianna.py utils tests` *(fails: E501 line too long and other style errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68979d26e4248329b23243f7cb609226