### PR TITLE
Add optional SQLite thread store

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ server restarts. Set `DEEPSEEK_API_KEY` in your environment to activate the
 DeepSeek integration before launching the bot.
 
 Thread ID mappings are written to `data/threads.json` with a file lock so
-concurrent processes do not corrupt the file. For better durability—especially
-before introducing client-id‑based multi-user flows—consider migrating this
-store to a lightweight database such as SQLite.
+concurrent processes do not corrupt the file. For better durability you can
+switch to SQLite storage: create an empty `data/threads.sqlite` file and
+restart the bot. When this file is present the mapping is stored in a
+`threads` table (`id TEXT PRIMARY KEY, thread_id TEXT`).
 
 ### Group chat behavior
 

--- a/utils/thread_store_sqlite.py
+++ b/utils/thread_store_sqlite.py
@@ -1,0 +1,49 @@
+import os
+import sqlite3
+import logging
+
+THREADS_DB_PATH = "data/threads.sqlite"
+logger = logging.getLogger(__name__)
+
+
+def _ensure_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS threads ("
+        "id TEXT PRIMARY KEY, thread_id TEXT)"
+    )
+    conn.commit()
+
+
+def load_threads(path: str = THREADS_DB_PATH) -> dict:
+    """Load stored thread mappings from SQLite."""
+    if not os.path.isfile(path):
+        return {}
+    try:
+        conn = sqlite3.connect(path)
+        try:
+            _ensure_table(conn)
+            cur = conn.execute("SELECT id, thread_id FROM threads")
+            return {row[0]: row[1] for row in cur.fetchall()}
+        finally:
+            conn.close()
+    except Exception:
+        logger.exception("Failed to load threads from %s", path)
+        return {}
+
+
+def save_threads(threads: dict, path: str = THREADS_DB_PATH) -> None:
+    """Save thread mappings to SQLite."""
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        conn = sqlite3.connect(path)
+        try:
+            _ensure_table(conn)
+            conn.executemany(
+                "INSERT OR REPLACE INTO threads (id, thread_id) VALUES (?, ?)",
+                list(threads.items()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception:
+        logger.exception("Failed to save threads to %s", path)


### PR DESCRIPTION
## Summary
- add SQLite-based thread store
- use SQLite for thread persistence when `data/threads.sqlite` exists
- document enabling SQLite storage

## Testing
- `flake8 --max-line-length=120 utils/arianna_engine.py utils/thread_store_sqlite.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68979d3523148329a6648f3ef62f7f56