### PR TITLE
Add robust logging for journal operations

### DIFF
--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,0 +1,36 @@
+import json
+import logging
+
+from utils import journal
+
+
+def test_log_event_appends_event(tmp_path, monkeypatch):
+    log_path = tmp_path / "journal.json"
+    monkeypatch.setattr(journal, "LOG_PATH", str(log_path))
+
+    journal.log_event({"action": "test"})
+
+    with open(log_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data[0]["action"] == "test"
+    assert "ts" in data[0]
+
+
+def test_log_event_logs_exception_on_failure(monkeypatch, caplog, tmp_path):
+    log_path = tmp_path / "journal.json"
+    monkeypatch.setattr(journal, "LOG_PATH", str(log_path))
+
+    def fail_open(*args, **kwargs):
+        raise OSError("fail")
+
+    monkeypatch.setattr(journal, "open", fail_open, raising=False)
+
+    caplog.set_level(logging.ERROR, logger="journal")
+    journal.log_event({"action": "fail"})
+
+    assert any(
+        "Error writing log event" in record.message and record.levelno == logging.ERROR
+        for record in caplog.records
+    )
+

--- a/utils/journal.py
+++ b/utils/journal.py
@@ -1,14 +1,18 @@
 import os
 import json
 from datetime import datetime
+import logging
 
 LOG_PATH = "data/journal.json"
 WILDERNESS_PATH = "data/wilderness.md"
 
+logger = logging.getLogger("journal")
+
+
 def log_event(event):
     """
     Appends an event with a timestamp to the journal log in JSON format.
-    Silently ignores errors.
+    Errors are logged.
     """
     try:
         if not os.path.isfile(LOG_PATH):
@@ -20,15 +24,15 @@ def log_event(event):
         with open(LOG_PATH, "w", encoding="utf-8") as f:
             json.dump(log, f, ensure_ascii=False, indent=2)
     except Exception:
-        pass
+        logger.exception("Error writing log event")
 
 def wilderness_log(fragment):
     """
     Appends a fragment of text to the wilderness markdown log.
-    Silently ignores errors.
+    Errors are logged.
     """
     try:
         with open(WILDERNESS_PATH, "a", encoding="utf-8") as f:
             f.write(fragment.strip() + "\n\n")
     except Exception:
-        pass
+        logger.exception("Error writing wilderness fragment")


### PR DESCRIPTION
## Summary
- add dedicated `journal` logger and log exceptions instead of silently passing
- cover journal logging with tests, including error path

## Testing
- `python -m py_compile utils/journal.py tests/test_journal.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68979d4a02fc8329969791e10592fe84