### PR TITLE
feat: support optional formatting and typing action

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,8 @@ SKIP_SHORT_PROB=0.5
 FOLLOWUP_PROB=0.2
 FOLLOWUP_DELAY_MIN=900
 FOLLOWUP_DELAY_MAX=7200
+
+# === Formatting ===
+TELEGRAM_PARSE_MODE=MarkdownV2
+# Set to any value to disable parse mode formatting
+# TELEGRAM_DISABLE_FORMATTING=1

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -47,11 +47,17 @@ engine = AriannaEngine()
 BOT_USERNAME = ""
 BOT_ID = 0
 
+DISABLE_FORMATTING = os.getenv("TELEGRAM_DISABLE_FORMATTING")
+PARSE_MODE = None if DISABLE_FORMATTING else os.getenv("TELEGRAM_PARSE_MODE", "MarkdownV2")
+
 async def send_message(chat_id: int, text: str) -> None:
+    payload = {"chat_id": chat_id, "text": text}
+    if PARSE_MODE:
+        payload["parse_mode"] = PARSE_MODE
     async with httpx.AsyncClient() as client:
         await client.post(
             f"https://api.telegram.org/bot{BOT_TOKEN}/sendMessage",
-            json={"chat_id": chat_id, "text": text},
+            json=payload,
             timeout=30,
         )
 


### PR DESCRIPTION
## Summary
- send MarkdownV2 or HTML formatted messages with optional env flag
- show typing action before delayed responses
- document Telegram formatting environment variables

## Testing
- `ruff check server_arianna.py webhook_server.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68979d578ab0832980d2070fef05726e