### PR TITLE
refactor: centralize link snippet logic

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -17,7 +17,6 @@ from utils.arianna_engine import AriannaEngine
 from utils.vector_store import semantic_search, vectorize_all_files
 from utils.deepseek_search import DEEPSEEK_ENABLED
 from utils.bot_handlers import (
-    append_link_snippets,
     parse_command,
     dispatch_response,
     DEEPSEEK_CMD,
@@ -25,6 +24,7 @@ from utils.bot_handlers import (
     INDEX_CMD,
     SKIP_SHORT_PROB,
 )
+from utils.link_snippets import append_link_snippets
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from utils import bot_handlers as bh  # noqa: E402
+from utils import link_snippets as ls  # noqa: E402
 
 
 def test_append_link_snippets(monkeypatch):
@@ -12,9 +13,9 @@ def test_append_link_snippets(monkeypatch):
         return "Example content"
 
     async def run_test():
-        monkeypatch.setattr(bh, "extract_text_from_url", fake_extract)
+        monkeypatch.setattr(ls, "extract_text_from_url", fake_extract)
         text = "Check https://example.com"
-        result = await bh.append_link_snippets(text)
+        result = await ls.append_link_snippets(text)
         assert "Example content" in result
         assert text in result
 

--- a/utils/bot_handlers.py
+++ b/utils/bot_handlers.py
@@ -1,38 +1,15 @@
 import os
-import re
-import asyncio
 from typing import Callable, Awaitable, Optional
 
 from utils.split_message import split_message
-from utils.text_helpers import extract_text_from_url
 
 DEEPSEEK_CMD = "/ds"
 SEARCH_CMD = "/search"
 INDEX_CMD = "/index"
 
-URL_REGEX = re.compile(r"https://\S+")
-URL_FETCH_TIMEOUT = int(os.getenv("URL_FETCH_TIMEOUT", 10))
-
 SKIP_SHORT_PROB = float(os.getenv("SKIP_SHORT_PROB", 0.5))
 
 SendFunc = Callable[[str], Awaitable[None]]
-
-
-async def append_link_snippets(text: str) -> str:
-    """Append snippet from any https:// link in the text."""
-    urls = URL_REGEX.findall(text)
-    if not urls:
-        return text
-    tasks = [asyncio.wait_for(extract_text_from_url(url), URL_FETCH_TIMEOUT) for url in urls]
-    snippets = await asyncio.gather(*tasks, return_exceptions=True)
-    parts = [text]
-    for url, snippet in zip(urls, snippets):
-        snippet_text = (
-            f"[Error loading page: {snippet}]" if isinstance(snippet, Exception) else snippet
-        )
-        parts.append(f"\n[Snippet from {url}]\n{snippet_text[:500]}")
-    return "\n".join(parts)
-
 
 def parse_command(text: str) -> tuple[Optional[str], str]:
     """Return (command, argument) if text starts with a known command."""

--- a/utils/link_snippets.py
+++ b/utils/link_snippets.py
@@ -1,0 +1,39 @@
+"""Utility for appending web page snippets to messages containing links."""
+
+import os
+import re
+import asyncio
+
+from utils.text_helpers import extract_text_from_url
+
+
+URL_REGEX = re.compile(r"https://\S+")
+URL_FETCH_TIMEOUT = int(os.getenv("URL_FETCH_TIMEOUT", 10))
+
+
+async def append_link_snippets(text: str) -> str:
+    """Append snippet from any https:// link in the given text.
+
+    For each URL found in *text*, fetch the page content and append a short
+    snippet to the original message. Errors while fetching are reported inline.
+    """
+
+    urls = URL_REGEX.findall(text)
+    if not urls:
+        return text
+
+    tasks = [asyncio.wait_for(extract_text_from_url(url), URL_FETCH_TIMEOUT) for url in urls]
+    snippets = await asyncio.gather(*tasks, return_exceptions=True)
+
+    parts = [text]
+    for url, snippet in zip(urls, snippets):
+        snippet_text = (
+            f"[Error loading page: {snippet}]" if isinstance(snippet, Exception) else snippet
+        )
+        parts.append(f"\n[Snippet from {url}]\n{snippet_text[:500]}")
+
+    return "\n".join(parts)
+
+
+__all__ = ["append_link_snippets"]
+

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -10,7 +10,6 @@ from utils.arianna_engine import AriannaEngine
 from utils.vector_store import semantic_search, vectorize_all_files
 from utils.deepseek_search import DEEPSEEK_ENABLED
 from utils.bot_handlers import (
-    append_link_snippets,
     parse_command,
     dispatch_response,
     DEEPSEEK_CMD,
@@ -18,6 +17,7 @@ from utils.bot_handlers import (
     INDEX_CMD,
     SKIP_SHORT_PROB,
 )
+from utils.link_snippets import append_link_snippets
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- add `utils/link_snippets.append_link_snippets` for shared link snippet extraction
- update `server_arianna` and `webhook_server` to use the new helper
- simplify `bot_handlers` and adjust tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68979d6ed12c8329827f054d7b69053d