### PR TITLE
Add lockfile and dependency check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest pytest-asyncio flake8
+      - name: Check lock file
+        run: |
+          pip freeze | sort > requirements.lock.ci
+          diff -u requirements.lock requirements.lock.ci
+          rm requirements.lock.ci
       - name: Lint
         run: flake8 utils tests
       - name: Test

--- a/requirements.lock
+++ b/requirements.lock
@@ -15,6 +15,7 @@ defusedxml==0.7.1
 distro==1.9.0
 fastapi==0.116.1
 filelock==3.18.0
+flake8==7.3.0
 frozenlist==1.7.0
 h11==0.16.0
 httpcore==1.0.9
@@ -24,6 +25,7 @@ iniconfig==2.1.0
 isort==6.0.1
 jiter==0.10.0
 lxml==6.0.0
+mccabe==0.7.0
 multidict==6.6.3
 mypy==1.17.1
 mypy_extensions==1.1.0
@@ -40,11 +42,14 @@ pluggy==1.6.0
 propcache==0.3.2
 pyaes==1.6.1
 pyasn1==0.6.1
+pycodestyle==2.14.0
 pydantic==2.11.7
 pydantic_core==2.33.2
 pydub==0.25.1
+pyflakes==3.4.0
 pypdf==5.9.0
 pyright==1.1.403
+pytest-asyncio==1.1.0
 pytest==8.4.1
 python-dateutil==2.9.0.post0
 python-docx==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# For reproducible installs, use requirements.lock generated via "pip freeze"
 telethon==1.40.0
 openai==1.99.6
 filelock==3.18.0


### PR DESCRIPTION
## Summary
- generate requirements.lock via `pip freeze`
- document lockfile usage in requirements.txt
- check lockfile freshness in CI

## Testing
- `flake8 utils tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68979daa096c8329b9c4c6f08d4bed82