### PR TITLE
Add Markdown parse mode with escaping

### DIFF
--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -49,3 +49,10 @@ def test_dispatch_response_splits():
     assert len(parts) == 2
     assert parts[0] == "a" * 4000
     assert parts[1] == "a" * 1000
+
+
+def test_escape_markdown_handles_links_and_code_blocks():
+    text = "Check https://example.com/test_underscore and code:\n```python\nprint(1)\n```"
+    escaped = bh.escape_markdown(text)
+    assert r"https://example\.com/test\_underscore" in escaped
+    assert "```python\nprint(1)\n```" in escaped

--- a/utils/bot_handlers.py
+++ b/utils/bot_handlers.py
@@ -6,6 +6,18 @@ from typing import Callable, Awaitable, Optional
 from utils.split_message import split_message
 from utils.text_helpers import extract_text_from_url
 
+MD_SPECIAL_CHARS = r"_*[]()~`>#+-=|{}.!"
+
+
+def escape_markdown(text: str) -> str:
+    """Escape Telegram Markdown special characters outside code blocks."""
+
+    def _escape(segment: str) -> str:
+        return re.sub(f"([{re.escape(MD_SPECIAL_CHARS)}])", r"\\\1", segment)
+
+    parts = re.split(r"(```.*?```)", text, flags=re.DOTALL)
+    return "".join(part if part.startswith("```") else _escape(part) for part in parts)
+
 DEEPSEEK_CMD = "/ds"
 SEARCH_CMD = "/search"
 INDEX_CMD = "/index"

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -17,6 +17,7 @@ from utils.bot_handlers import (
     SEARCH_CMD,
     INDEX_CMD,
     SKIP_SHORT_PROB,
+    escape_markdown,
 )
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -51,7 +52,11 @@ async def send_message(chat_id: int, text: str) -> None:
     async with httpx.AsyncClient() as client:
         await client.post(
             f"https://api.telegram.org/bot{BOT_TOKEN}/sendMessage",
-            json={"chat_id": chat_id, "text": text},
+            json={
+                "chat_id": chat_id,
+                "text": escape_markdown(text),
+                "parse_mode": "Markdown",
+            },
             timeout=30,
         )
 


### PR DESCRIPTION
## Summary
- escape Telegram Markdown special characters with a new helper
- send messages using Markdown parse mode for both webhook and client
- cover escaping logic with tests for links and code blocks

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68979dc112448329abc39c197208d2cc