### PR TITLE
Implement thread trimming and cleanup for old conversations

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -15,6 +15,7 @@ from telethon.tl.types import MessageEntityMention
 from telethon.sessions import StringSession
 
 from utils.arianna_engine import AriannaEngine
+from utils.thread_store_sqlite import cleanup_old_threads
 from utils.vector_store import semantic_search, vectorize_all_files
 from utils.deepseek_search import DEEPSEEK_ENABLED
 from utils.bot_handlers import (
@@ -74,6 +75,8 @@ def create_telegram_client(
     return TelegramClient(session_name, API_ID, API_HASH)
 
 
+THREAD_TTL_DAYS = int(os.getenv("THREAD_TTL_DAYS", "30"))
+cleanup_old_threads(THREAD_TTL_DAYS)
 client = create_telegram_client(phone=PHONE, bot_token=BOT_TOKEN, session_string=SESSION_STRING)
 engine = AriannaEngine()
 openai_client = openai.AsyncOpenAI(api_key=OPENAI_API_KEY)

--- a/utils/thread_store_sqlite.py
+++ b/utils/thread_store_sqlite.py
@@ -2,6 +2,7 @@ import os
 import json
 import sqlite3
 import logging
+import time
 
 THREADS_DB_PATH = "data/threads.sqlite"
 THREADS_JSON_PATH = "data/threads.json"
@@ -16,10 +17,18 @@ def _init_db(path: str) -> None:
             """
             CREATE TABLE IF NOT EXISTS threads (
                 user_id TEXT PRIMARY KEY,
-                thread_id TEXT NOT NULL
+                thread_id TEXT NOT NULL,
+                last_used INTEGER NOT NULL
             )
             """
         )
+        # try add column if existing DB lacks it
+        try:
+            conn.execute("SELECT last_used FROM threads LIMIT 1")
+        except sqlite3.OperationalError:
+            conn.execute(
+                "ALTER TABLE threads ADD COLUMN last_used INTEGER NOT NULL DEFAULT (strftime('%s','now'))"
+            )
         conn.commit()
 
 def load_threads(db_path: str = THREADS_DB_PATH) -> dict:
@@ -51,12 +60,40 @@ def save_threads(threads: dict, db_path: str = THREADS_DB_PATH) -> None:
     """Save thread mappings to SQLite."""
     try:
         _init_db(db_path)
+        now = int(time.time())
         with sqlite3.connect(db_path) as conn:
-            conn.execute("DELETE FROM threads")
             conn.executemany(
-                "INSERT OR REPLACE INTO threads (user_id, thread_id) VALUES (?, ?)",
-                threads.items(),
+                """
+                INSERT OR REPLACE INTO threads (user_id, thread_id, last_used)
+                VALUES (?, ?, ?)
+                """,
+                [(u, t, now) for u, t in threads.items()],
             )
             conn.commit()
     except Exception:
         logger.exception("Failed to save threads to %s", db_path)
+
+
+def touch_thread(user_id: str, db_path: str = THREADS_DB_PATH) -> None:
+    """Update last_used for the given user id."""
+    try:
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "UPDATE threads SET last_used = ? WHERE user_id = ?",
+                (int(time.time()), user_id),
+            )
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to update last_used for %s", user_id)
+
+
+def cleanup_old_threads(max_age_days: int, db_path: str = THREADS_DB_PATH) -> None:
+    """Remove threads older than max_age_days."""
+    try:
+        _init_db(db_path)
+        cutoff = int(time.time()) - max_age_days * 86400
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("DELETE FROM threads WHERE last_used < ?", (cutoff,))
+            conn.commit()
+    except Exception:
+        logger.exception("Failed to cleanup old threads")

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -7,6 +7,7 @@ import httpx
 from fastapi import FastAPI, Request
 
 from utils.arianna_engine import AriannaEngine
+from utils.thread_store_sqlite import cleanup_old_threads
 from utils.vector_store import semantic_search, vectorize_all_files
 from utils.deepseek_search import DEEPSEEK_ENABLED
 from utils.bot_handlers import (
@@ -45,6 +46,8 @@ if not OPENAI_API_KEY:
     raise SystemExit("Missing OPENAI_API_KEY")
 
 app = FastAPI()
+THREAD_TTL_DAYS = int(os.getenv("THREAD_TTL_DAYS", "30"))
+cleanup_old_threads(THREAD_TTL_DAYS)
 engine = AriannaEngine()
 
 BOT_USERNAME = ""


### PR DESCRIPTION
## Summary
- Limit thread size by summarising and pruning older messages
- Track last-used timestamps in the SQLite thread store and purge stale threads
- Clean up expired threads when bot starts

## Testing
- `python -m flake8 utils/arianna_engine.py utils/thread_store_sqlite.py server_arianna.py webhook_server.py` *(fails: E501 line too long, E221, E302, etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897b2752e788329a021d0889ff6468f