### PR TITLE
Reuse global HTTPX client for Telegram messages

### DIFF
--- a/tests/test_send_message_client.py
+++ b/tests/test_send_message_client.py
@@ -1,0 +1,39 @@
+import importlib
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_send_multiple_messages(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "token")
+    monkeypatch.setenv("OPENAI_API_KEY", "key")
+
+    webhook_server = importlib.import_module("webhook_server")
+    webhook_server = importlib.reload(webhook_server)
+    original_client = webhook_server.tg_client
+
+    calls = []
+
+    def handler(request):
+        calls.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    webhook_server.tg_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler)
+    )
+    await original_client.aclose()
+
+    class DummyEngine:
+        async def aclose(self):
+            pass
+
+    monkeypatch.setattr(webhook_server, "engine", DummyEngine())
+
+    for i in range(3):
+        await webhook_server.send_message(1, f"msg {i}")
+
+    assert len(calls) == 3
+
+    await webhook_server.shutdown()
+    assert webhook_server.tg_client.is_closed

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -53,16 +53,17 @@ BOT_ID = 0
 DISABLE_FORMATTING = os.getenv("TELEGRAM_DISABLE_FORMATTING")
 PARSE_MODE = None if DISABLE_FORMATTING else os.getenv("TELEGRAM_PARSE_MODE", "MarkdownV2")
 
+tg_client = httpx.AsyncClient()
+
 async def send_message(chat_id: int, text: str) -> None:
     payload = {"chat_id": chat_id, "text": text}
     if PARSE_MODE:
         payload["parse_mode"] = PARSE_MODE
-    async with httpx.AsyncClient() as client:
-        await client.post(
-            f"https://api.telegram.org/bot{BOT_TOKEN}/sendMessage",
-            json=payload,
-            timeout=30,
-        )
+    await tg_client.post(
+        f"https://api.telegram.org/bot{BOT_TOKEN}/sendMessage",
+        json=payload,
+        timeout=30,
+    )
 
 @app.on_event("startup")
 async def startup() -> None:
@@ -89,6 +90,7 @@ async def startup() -> None:
 @app.on_event("shutdown")
 async def shutdown() -> None:
     await engine.aclose()
+    await tg_client.aclose()
 
 @app.get("/")
 async def root() -> dict:


### PR DESCRIPTION
## Summary
- use a global `httpx.AsyncClient` for Telegram communication
- close the shared client on shutdown
- add regression test for sending multiple messages sequentially

## Testing
- `python -m flake8 tests/test_send_message_client.py`
- `python -m flake8 webhook_server.py` *(fails: line too long, missing blank lines, etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897b2c229648329a94dd1a6b66d443a