### PR TITLE
Prompt for short messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Several optional variables fine‑tune the bot's behavior:
 
 - `GROUP_DELAY_MIN`/`GROUP_DELAY_MAX` – range in seconds to wait before replying in groups (default 120–600).
 - `PRIVATE_DELAY_MIN`/`PRIVATE_DELAY_MAX` – range for private chats (default 30–180).
-- `SKIP_SHORT_PROB` – chance to ignore very short or non‑question messages (default 0.5; set to 0 to disable).
+- `SKIP_SHORT_PROB` – chance to ignore very short or non‑question messages in group chats (default 0.5). Skipped messages receive the hint "Уточните вопрос." Private chats use 0 by default.
 - `FOLLOWUP_PROB` – probability of sending a follow‑up later (default 0.2).
 - `FOLLOWUP_DELAY_MIN`/`FOLLOWUP_DELAY_MAX` – delay range for follow‑ups in seconds (default 900–7200).
 
@@ -138,17 +138,14 @@ the model more context from the referenced site.
 
 Arianna purposely waits a little before answering. The delay range depends on
 the chat type and is configurable via the environment variables listed above.
-Short statements or messages without a question mark are ignored about half of
-the time. Occasionally she will send a brief follow‑up message referencing the
-earlier conversation.
+In group chats, short statements or messages without a question mark are ignored about half of the time (controlled by `SKIP_SHORT_PROB`). When skipped, the bot replies with "Уточните вопрос." Private chats process them by default. Occasionally she will send a brief follow‑up message referencing the earlier conversation.
 
 ### Why the bot might not respond
 
 The bot intentionally filters some messages:
 
 - In group chats she replies only when mentioned or when you answer one of her messages.
-- Very short texts or those without a question mark are skipped with probability controlled by `SKIP_SHORT_PROB` (default `0.5`).
-  Set `SKIP_SHORT_PROB=0` to disable this random skipping.
+- Very short texts or those without a question mark are skipped with probability controlled by `SKIP_SHORT_PROB` (default `0.5` in groups, `0` in private chats). When this happens, the bot replies with "Уточните вопрос." Set `SKIP_SHORT_PROB=0` to disable this in groups as well.
 - Voice messages that cannot be transcribed are ignored.
 
 ## Deployment

--- a/server_arianna.py
+++ b/server_arianna.py
@@ -228,8 +228,10 @@ async def voice_messages(event):
         return
     text = await append_link_snippets(text)
     if len(text.split()) < 4 or '?' not in text:
-        if random.random() < SKIP_SHORT_PROB:
+        skip_prob = SKIP_SHORT_PROB if is_group else 0.0
+        if random.random() < skip_prob:
             logger.info("Skipping voice message: too short or no question")
+            await event.reply("Уточните вопрос.")
             return
     logger.info("Voice message text: %s", text)
     try:
@@ -335,8 +337,10 @@ async def all_messages(event):
         return
 
     if len(text.split()) < 4 or '?' not in text:
-        if random.random() < SKIP_SHORT_PROB:
+        skip_prob = SKIP_SHORT_PROB if is_group else 0.0
+        if random.random() < skip_prob:
             logger.info("Skipping message: too short or no question")
+            await event.reply("Уточните вопрос.")
             return
 
     thread_key = user_id if not is_group else str(event.chat_id)


### PR DESCRIPTION
## Summary
- ask users to clarify when short messages are skipped
- don't skip short messages in private chats by default
- document short-message skipping behavior

## Testing
- `flake8 server_arianna.py README.md` *(fails: line-length violations and invalid characters)*
- `pytest` *(fails: async plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897b2d2cbbc8329a849e84595ba14a9