### PR TITLE
Switch journal to JSONL format

### DIFF
--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -11,7 +11,7 @@ def test_log_event_appends_event(tmp_path, monkeypatch):
     journal.log_event({"action": "test"})
 
     with open(log_path, "r", encoding="utf-8") as f:
-        data = json.load(f)
+        data = [json.loads(line) for line in f if line.strip()]
 
     assert data[0]["action"] == "test"
     assert "ts" in data[0]

--- a/utils/journal.py
+++ b/utils/journal.py
@@ -11,18 +11,16 @@ logger = logging.getLogger("journal")
 
 def log_event(event):
     """
-    Appends an event with a timestamp to the journal log in JSON format.
+    Append an event with a timestamp to the journal log in JSON Lines format.
     Errors are logged.
     """
     try:
-        if not os.path.isfile(LOG_PATH):
-            with open(LOG_PATH, "w", encoding="utf-8") as f:
-                f.write("[]")
-        with open(LOG_PATH, "r", encoding="utf-8") as f:
-            log = json.load(f)
-        log.append({"ts": datetime.now().isoformat(), **event})
-        with open(LOG_PATH, "w", encoding="utf-8") as f:
-            json.dump(log, f, ensure_ascii=False, indent=2)
+        os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+        with open(LOG_PATH, "a", encoding="utf-8") as f:
+            f.write(
+                json.dumps({"ts": datetime.now().isoformat(), **event}, ensure_ascii=False)
+                + "\n"
+            )
     except Exception:
         logger.exception("Error writing log event")
 


### PR DESCRIPTION
## Summary
- write journal events as JSON Lines without loading the whole file
- adjust journal tests to parse JSONL

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897b349c1ac8329a0fc28a3a92eca88