### PR TITLE
Add thread cleanup with timestamps

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -375,6 +375,7 @@ async def main():
         logger.exception("Assistant initialization failed")
         await engine.aclose()
         raise SystemExit(1)
+    engine.start_cleanup_task()
     logger.info("🚀 Arianna client started")
     try:
         await client.run_until_disconnected()

--- a/tests/test_thread_cleanup.py
+++ b/tests/test_thread_cleanup.py
@@ -1,0 +1,29 @@
+import time
+
+from utils.arianna_engine import AriannaEngine
+
+
+def test_cleanup_threads(monkeypatch):
+    """Older threads should be removed and saved."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    # Avoid touching real storage
+    monkeypatch.setattr("utils.arianna_engine.load_threads", lambda: {})
+    saved = {}
+
+    def fake_save(data):
+        saved.update(data)
+
+    monkeypatch.setattr("utils.arianna_engine.save_threads", fake_save)
+
+    engine = AriannaEngine()
+    now = int(time.time())
+    engine.threads = {
+        "recent": {"thread_id": "t1", "last_access": now},
+        "old": {"thread_id": "t2", "last_access": now - 40 * 86400},
+    }
+
+    engine.cleanup_threads(max_age_days=30)
+
+    assert "old" not in engine.threads
+    assert "recent" in engine.threads
+    assert saved == engine.threads

--- a/utils/thread_store_sqlite.py
+++ b/utils/thread_store_sqlite.py
@@ -2,6 +2,7 @@ import os
 import json
 import sqlite3
 import logging
+import time
 
 THREADS_DB_PATH = "data/threads.sqlite"
 THREADS_JSON_PATH = "data/threads.json"
@@ -9,17 +10,30 @@ logger = logging.getLogger(__name__)
 
 
 def _init_db(path: str) -> None:
-    """Ensure the SQLite database and table exist."""
+    """Ensure the SQLite database and table exist.
+
+    If the table is missing the ``last_access`` column (from older versions),
+    it will be added automatically.
+    """
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with sqlite3.connect(path) as conn:
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS threads (
                 user_id TEXT PRIMARY KEY,
-                thread_id TEXT NOT NULL
+                thread_id TEXT NOT NULL,
+                last_access INTEGER NOT NULL
             )
             """
         )
+        # Ensure ``last_access`` column exists for legacy databases
+        cols = {
+            row[1] for row in conn.execute("PRAGMA table_info(threads)")
+        }
+        if "last_access" not in cols:
+            conn.execute(
+                "ALTER TABLE threads ADD COLUMN last_access INTEGER DEFAULT (strftime('%s','now'))"
+            )
         conn.commit()
 
 def load_threads(db_path: str = THREADS_DB_PATH) -> dict:
@@ -31,13 +45,23 @@ def load_threads(db_path: str = THREADS_DB_PATH) -> dict:
     try:
         _init_db(db_path)
         with sqlite3.connect(db_path) as conn:
-            cursor = conn.execute("SELECT user_id, thread_id FROM threads")
-            threads = {user_id: thread_id for user_id, thread_id in cursor.fetchall()}
+            cursor = conn.execute(
+                "SELECT user_id, thread_id, last_access FROM threads"
+            )
+            threads = {
+                user_id: {"thread_id": thread_id, "last_access": last_access}
+                for user_id, thread_id, last_access in cursor.fetchall()
+            }
 
         if not threads and os.path.isfile(THREADS_JSON_PATH):
             try:
                 with open(THREADS_JSON_PATH, "r", encoding="utf-8") as f:
-                    threads = json.load(f)
+                    legacy = json.load(f)
+                now = int(time.time())
+                threads = {
+                    user_id: {"thread_id": tid, "last_access": now}
+                    for user_id, tid in legacy.items()
+                }
                 save_threads(threads, db_path)
                 os.remove(THREADS_JSON_PATH)
             except Exception:
@@ -54,8 +78,11 @@ def save_threads(threads: dict, db_path: str = THREADS_DB_PATH) -> None:
         with sqlite3.connect(db_path) as conn:
             conn.execute("DELETE FROM threads")
             conn.executemany(
-                "INSERT OR REPLACE INTO threads (user_id, thread_id) VALUES (?, ?)",
-                threads.items(),
+                "INSERT OR REPLACE INTO threads (user_id, thread_id, last_access) VALUES (?, ?, ?)",
+                [
+                    (user_id, data["thread_id"], data["last_access"])
+                    for user_id, data in threads.items()
+                ],
             )
             conn.commit()
     except Exception:

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -84,6 +84,7 @@ async def startup() -> None:
         logger.exception("Assistant initialization failed")
         await engine.aclose()
         raise SystemExit(1)
+    engine.start_cleanup_task()
     logger.info("🚀 Webhook server started")
 
 @app.on_event("shutdown")


### PR DESCRIPTION
## Summary
- track last access timestamps for threads and remove stale entries
- schedule periodic thread cleanup when the bot starts
- test thread cleanup behavior

## Testing
- `flake8 utils tests` *(fails: line too long, blank lines, etc)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897b3540d488329971a9e10177ca25e