### PR TITLE
Expose simple web app and link via Telegram

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -10,8 +10,8 @@ from typing import Optional
 import openai
 import httpx
 from pydub import AudioSegment
-from telethon import TelegramClient, events
-from telethon.tl.types import MessageEntityMention
+from telethon import TelegramClient, events, Button
+from telethon.tl.types import MessageEntityMention, WebAppInfo
 from telethon.sessions import StringSession
 
 from utils.arianna_engine import AriannaEngine
@@ -89,6 +89,9 @@ HELP_TEXT = (
     f"{VOICE_OFF_CMD} - disable voice responses\n"
     f"{HELP_CMD} - show this help message"
 )
+
+BASE_URL = os.getenv("TELEGRAM_WEBHOOK_URL", "http://localhost:8000")
+WEBAPP_URL = f"{BASE_URL.rstrip('/')}/webapp"
 
 # --- optional behavior tuning ---
 GROUP_DELAY_MIN   = int(os.getenv("GROUP_DELAY_MIN", 120))   # 2 minutes
@@ -288,7 +291,8 @@ async def all_messages(event):
         await event.reply("Voice responses disabled")
         return
     if text.strip().lower() == HELP_CMD:
-        await event.reply(HELP_TEXT)
+        button = Button.web_app("⚙️ Settings", WebAppInfo(WEBAPP_URL))
+        await event.reply(HELP_TEXT, buttons=button)
         return
 
     if cmd == DEEPSEEK_CMD:

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Settings</title>
+</head>
+<body>
+  <h1>Settings</h1>
+  <p>Configure the bot here.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Serve new `/webapp` route with a minimal Settings page
- Provide WebApp Settings button in Telegram help menu
- Wire button and helper URL setup for both webhook and client modes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897b3969b6883299db348b309bd015d