### PR TITLE
Handle bot username suffix in command parsing

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -256,7 +256,7 @@ async def all_messages(event):
     user_id = str(event.sender_id)
     text = event.raw_text or ""
 
-    cmd, arg = parse_command(text)
+    cmd, arg = parse_command(text, BOT_USERNAME)
     if cmd == SEARCH_CMD:
         if not arg:
             logger.info("Search command missing argument")

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -35,6 +35,12 @@ def test_parse_command():
     assert arg == "no command here"
 
 
+def test_parse_command_with_bot_username():
+    cmd, arg = bh.parse_command("/voiceon@mybot", bot_username="mybot")
+    assert cmd == bh.VOICE_ON_CMD
+    assert arg == ""
+
+
 def test_dispatch_response_splits():
     parts = []
 

--- a/utils/bot_handlers.py
+++ b/utils/bot_handlers.py
@@ -9,6 +9,7 @@ from utils.text_helpers import extract_text_from_url
 DEEPSEEK_CMD = "/ds"
 SEARCH_CMD = "/search"
 INDEX_CMD = "/index"
+VOICE_ON_CMD = "/voiceon"
 
 URL_REGEX = re.compile(r"https://\S+")
 URL_FETCH_TIMEOUT = int(os.getenv("URL_FETCH_TIMEOUT", 10))
@@ -25,22 +26,46 @@ async def append_link_snippets(text: str) -> str:
     urls = URL_REGEX.findall(text)
     if not urls:
         return text
-    tasks = [asyncio.wait_for(extract_text_from_url(url), URL_FETCH_TIMEOUT) for url in urls]
+    tasks = [
+        asyncio.wait_for(extract_text_from_url(url), URL_FETCH_TIMEOUT)
+        for url in urls
+    ]
     snippets = await asyncio.gather(*tasks, return_exceptions=True)
     parts = [text]
     for url, snippet in zip(urls, snippets):
         snippet_text = (
-            f"[Error loading page: {snippet}]" if isinstance(snippet, Exception) else snippet
+            f"[Error loading page: {snippet}]"
+            if isinstance(snippet, Exception)
+            else snippet
         )
         parts.append(f"\n[Snippet from {url}]\n{snippet_text[:500]}")
     return "\n".join(parts)
 
 
-def parse_command(text: str) -> tuple[Optional[str], str]:
-    """Return (command, argument) if text starts with a known command."""
+def parse_command(
+    text: str, bot_username: Optional[str] = None
+) -> tuple[Optional[str], str]:
+    """Return (command, argument) if text starts with a known command.
+
+    If ``bot_username`` is provided, an ``@<bot_username>`` suffix in the
+    command is removed before matching.
+    """
     stripped = text.strip()
+    if not stripped:
+        return None, ""
+
+    first, *rest = stripped.split(maxsplit=1)
+    lowered_first = first.lower()
+    if bot_username:
+        suffix = f"@{bot_username.lower()}"
+        if lowered_first.endswith(suffix):
+            first = first[:-len(suffix)]
+            lowered_first = lowered_first[:-len(suffix)]
+
+    stripped = first + (" " + rest[0] if rest else "")
     lowered = stripped.lower()
-    for cmd in (SEARCH_CMD, INDEX_CMD, DEEPSEEK_CMD):
+
+    for cmd in (SEARCH_CMD, INDEX_CMD, DEEPSEEK_CMD, VOICE_ON_CMD):
         if lowered.startswith(cmd):
             arg = stripped[len(cmd):].lstrip()
             return cmd, arg

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -109,7 +109,7 @@ async def telegram_webhook(request: Request) -> dict:
     if not text:
         return {"ok": True}
 
-    cmd, arg = parse_command(text)
+    cmd, arg = parse_command(text, BOT_USERNAME)
     if cmd == SEARCH_CMD:
         if arg:
             chunks = await semantic_search(arg, engine.openai_key)


### PR DESCRIPTION
## Summary
- strip `@<bot_username>` suffix when parsing commands
- pass bot username to command parser in servers
- cover `/voiceon@mybot` parsing in tests

## Testing
- `flake8`
- `pytest` *(fails: async def functions are not natively supported)*
- `pytest tests/test_bot_handlers.py::test_parse_command_with_bot_username -q`


------
https://chatgpt.com/codex/tasks/task_e_6897b3a666f083298b41d5d7a366c57f