### PR TITLE
Disable random message skipping and request clarification

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -24,7 +24,6 @@ from utils.bot_handlers import (
     DEEPSEEK_CMD,
     SEARCH_CMD,
     INDEX_CMD,
-    SKIP_SHORT_PROB,
 )
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -228,9 +227,9 @@ async def voice_messages(event):
         return
     text = await append_link_snippets(text)
     if len(text.split()) < 4 or '?' not in text:
-        if random.random() < SKIP_SHORT_PROB:
-            logger.info("Skipping voice message: too short or no question")
-            return
+        await event.reply("Please clarify your question.")
+        logger.info("Requesting clarification for voice message: too short or no question")
+        return
     logger.info("Voice message text: %s", text)
     try:
         resp = await engine.ask(thread_key, text, is_group=is_group)
@@ -335,9 +334,9 @@ async def all_messages(event):
         return
 
     if len(text.split()) < 4 or '?' not in text:
-        if random.random() < SKIP_SHORT_PROB:
-            logger.info("Skipping message: too short or no question")
-            return
+        await event.reply("Please clarify your question.")
+        logger.info("Requesting clarification: message too short or no question")
+        return
 
     thread_key = user_id if not is_group else str(event.chat_id)
     prompt = await append_link_snippets(text)

--- a/utils/bot_handlers.py
+++ b/utils/bot_handlers.py
@@ -13,9 +13,8 @@ INDEX_CMD = "/index"
 URL_REGEX = re.compile(r"https://\S+")
 URL_FETCH_TIMEOUT = int(os.getenv("URL_FETCH_TIMEOUT", 10))
 
-# Chance to ignore very short or non-question messages.
-# Set to 0 to disable random skipping.
-SKIP_SHORT_PROB = max(0.0, min(1.0, float(os.getenv("SKIP_SHORT_PROB", 0.5))))
+# Chance to ignore very short or non-question messages. Disabled to ensure the bot always responds.
+SKIP_SHORT_PROB = 0.0
 
 SendFunc = Callable[[str], Awaitable[None]]
 


### PR DESCRIPTION
## Summary
- Always disable random skipping of short or non-question messages
- Ask users to clarify when messages are too short or lack a question mark

## Testing
- `flake8` *(fails: line length and style errors across repository)*
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6897b3ec82608329909a31bad0704837