### PR TITLE
Register Telegram bot commands

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -11,7 +11,11 @@ import openai
 import httpx
 from pydub import AudioSegment
 from telethon import TelegramClient, events, Button
-from telethon.tl.types import MessageEntityMention
+from telethon.tl.types import (
+    MessageEntityMention,
+    BotCommand,
+    BotCommandScopeDefault,
+)
 from telethon.sessions import StringSession
 
 from utils.arianna_engine import AriannaEngine
@@ -428,6 +432,18 @@ async def main():
     else:
         await client.start(phone=PHONE)
     me = await client.get_me()
+    if BOT_TOKEN or getattr(me, "bot", False):
+        await client.set_bot_commands(
+            [
+                BotCommand(SEARCH_CMD.lstrip("/"), "Semantic search documents"),
+                BotCommand(INDEX_CMD.lstrip("/"), "Index documents"),
+                BotCommand(DEEPSEEK_CMD.lstrip("/"), "Ask DeepSeek"),
+                BotCommand(VOICE_ON_CMD.lstrip("/"), "Enable voice responses"),
+                BotCommand(VOICE_OFF_CMD.lstrip("/"), "Disable voice responses"),
+                BotCommand(HELP_CMD.lstrip("/"), "Show help"),
+            ],
+            scope=BotCommandScopeDefault(),
+        )
     BOT_USERNAME = (me.username or "").lower()
     BOT_ID = me.id
     try:


### PR DESCRIPTION
## Summary
- register available Telegram commands after bot startup
- import telethon BotCommand helpers for command registration

## Testing
- `flake8 server_arianna.py` *(fails: E501 line too long and other errors)*
- `black --check server_arianna.py` *(fails: would reformat server_arianna.py)*
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6898416f1a6c83298daeccb381360e1b