### PR TITLE
feat: add journal log rotation

### DIFF
--- a/utils/journal.py
+++ b/utils/journal.py
@@ -6,16 +6,27 @@ import logging
 LOG_PATH = "data/journal.json"
 WILDERNESS_PATH = "data/wilderness.md"
 
+# Rotate log when exceeding this size (in bytes)
+MAX_LOG_SIZE = 5 * 1024 * 1024  # 5 MB
+
 logger = logging.getLogger("journal")
+
+
+def _rotate_log(path):
+    """Rotate log if it exceeds ``MAX_LOG_SIZE``."""
+    if os.path.exists(path) and os.path.getsize(path) > MAX_LOG_SIZE:
+        ts = datetime.now().strftime("%Y%m%d%H%M%S")
+        os.rename(path, f"{path}.{ts}")
 
 
 def log_event(event):
     """
     Append an event with a timestamp to the journal log in JSON Lines format.
-    Errors are logged.
+    Errors are logged. Performs size-based rotation.
     """
     try:
         os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+        _rotate_log(LOG_PATH)
         with open(LOG_PATH, "a", encoding="utf-8") as f:
             f.write(
                 json.dumps({"ts": datetime.now().isoformat(), **event}, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- log journal events using JSON Lines and rotate when file exceeds 5MB
- test journal rotation behavior

## Testing
- `ruff check .`
- `pytest` *(fails: AttributeError: 'DummyClient' object has no attribute 'start' in tests/test_openai_client_close.py::test_openai_client_closed)*


------
https://chatgpt.com/codex/tasks/task_e_6898415e8f108329ae344f2bb41adc36