### PR TITLE
Use SQLite lookups for chat threads with cache

### DIFF
--- a/tests/test_openai_client_close.py
+++ b/tests/test_openai_client_close.py
@@ -45,6 +45,7 @@ async def test_openai_client_closed(monkeypatch):
     )
 
     server_arianna = importlib.import_module("server_arianna")
+    server_arianna = importlib.reload(server_arianna)
 
     monkeypatch.setattr(server_arianna.engine, "setup_assistant", AsyncMock())
     monkeypatch.setattr(server_arianna.engine, "aclose", AsyncMock())


### PR DESCRIPTION
## Summary
- add `get_thread` and `set_thread` helpers for SQLite thread storage
- switch `AriannaEngine` to per-user thread lookups with an LRU cache
- reload module in `test_openai_client_close` to isolate patched Telegram client

## Testing
- `flake8 utils/thread_store_sqlite.py utils/arianna_engine.py tests/test_openai_client_close.py` (fails: E302, E501, etc.)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689841621fcc8329abaab9d71d80a086