### PR TITLE
Add Telegram web app support

### DIFF
--- a/web_app/index.html
+++ b/web_app/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Arianna Web App</title>
+    <script>
+        function sendData() {
+            if (window.Telegram && Telegram.WebApp && Telegram.WebApp.sendData) {
+                Telegram.WebApp.sendData(document.getElementById('msg').value);
+            }
+        }
+    </script>
+</head>
+<body>
+    <h1>Arianna Web App</h1>
+    <input id="msg" placeholder="Type something" />
+    <button onclick="sendData()">Send to Bot</button>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add web app buttons to Telegram bot UIs
- serve static web app via FastAPI and process data from sendData

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898417ddbec8329986274dc7b550dc3