### PR TITLE
Reduce default response delays

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ python -m dotenv run -- python server_arianna.py
 Important variables include `TELEGRAM_API_ID`, `TELEGRAM_API_HASH`, `TELEGRAM_PHONE`, `TELEGRAM_SESSION_STRING`, and `OPENAI_API_KEY`. Set `DEEPSEEK_API_KEY` to enable the optional DeepSeek integration; the `/ds` command will be disabled if it is not provided. Set `TELEGRAM_BOT_TOKEN` (or legacy `TELEGRAM_TOKEN`) to run the client in bot mode. Pinecone settings (`PINECONE_API_KEY`, `PINECONE_INDEX`, `PINECONE_ENV`) are also required if you use semantic search.
 Several optional variables fine‑tune the bot's behavior:
 
-- `GROUP_DELAY_MIN`/`GROUP_DELAY_MAX` – range in seconds to wait before replying in groups (default 120–600).
-- `PRIVATE_DELAY_MIN`/`PRIVATE_DELAY_MAX` – range for private chats (default 30–180).
+- `GROUP_DELAY_MIN`/`GROUP_DELAY_MAX` – range in seconds to wait before replying in groups (default 0–5, override with environment variables).
+- `PRIVATE_DELAY_MIN`/`PRIVATE_DELAY_MAX` – range for private chats (default 0–5, override with environment variables).
 - `SKIP_SHORT_PROB` – chance to ignore very short or non‑question messages in group chats (default 0.5). Skipped messages receive the hint "Уточните вопрос." Private chats use 0 by default.
 - `FOLLOWUP_PROB` – probability of sending a follow‑up later (default 0.2).
 - `FOLLOWUP_DELAY_MIN`/`FOLLOWUP_DELAY_MAX` – delay range for follow‑ups in seconds (default 900–7200).

--- a/server_arianna.py
+++ b/server_arianna.py
@@ -105,11 +105,11 @@ def default_buttons():
     ]
 
 # --- optional behavior tuning ---
-GROUP_DELAY_MIN   = int(os.getenv("GROUP_DELAY_MIN", 120))   # 2 minutes
-GROUP_DELAY_MAX   = int(os.getenv("GROUP_DELAY_MAX", 600))   # 10 minutes
-PRIVATE_DELAY_MIN = int(os.getenv("PRIVATE_DELAY_MIN", 30))  # 30 seconds
-PRIVATE_DELAY_MAX = int(os.getenv("PRIVATE_DELAY_MAX", 180)) # 3 minutes
-FOLLOWUP_PROB     = float(os.getenv("FOLLOWUP_PROB", 0.2))
+GROUP_DELAY_MIN = float(os.getenv("GROUP_DELAY_MIN", 0))   # default 0 seconds
+GROUP_DELAY_MAX = float(os.getenv("GROUP_DELAY_MAX", 5))   # default 5 seconds
+PRIVATE_DELAY_MIN = float(os.getenv("PRIVATE_DELAY_MIN", 0))  # default 0 seconds
+PRIVATE_DELAY_MAX = float(os.getenv("PRIVATE_DELAY_MAX", 5))  # default 5 seconds
+FOLLOWUP_PROB = float(os.getenv("FOLLOWUP_PROB", 0.2))
 FOLLOWUP_DELAY_MIN = int(os.getenv("FOLLOWUP_DELAY_MIN", 900))   # 15 minutes
 FOLLOWUP_DELAY_MAX = int(os.getenv("FOLLOWUP_DELAY_MAX", 7200))  # 2 hours
 


### PR DESCRIPTION
## Summary
- shrink default group and private reply delays to 0–5 seconds
- clarify environment overrides for delay settings in documentation

## Testing
- `flake8` *(fails: E501 line too long, other style issues)*
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6898499d7ac88329a031e2ad2a95523c