### PR TITLE
Disable short-message skipping by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Several optional variables fine‑tune the bot's behavior:
 
 - `GROUP_DELAY_MIN`/`GROUP_DELAY_MAX` – range in seconds to wait before replying in groups (default 120–600).
 - `PRIVATE_DELAY_MIN`/`PRIVATE_DELAY_MAX` – range for private chats (default 30–180).
-- `SKIP_SHORT_PROB` – chance to ignore very short or non‑question messages in group chats (default 0.5). Skipped messages receive the hint "Уточните вопрос." Private chats use 0 by default.
+- `SKIP_SHORT_PROB` – chance to ignore very short or non‑question messages in group chats (default 0, meaning disabled). Skipped messages receive the hint "Уточните вопрос." Set `SKIP_SHORT_PROB` to a value between 0 and 1 (for example `0.5`) to re‑enable this behavior in groups. Private chats always use 0.
 - `FOLLOWUP_PROB` – probability of sending a follow‑up later (default 0.2).
 - `FOLLOWUP_DELAY_MIN`/`FOLLOWUP_DELAY_MAX` – delay range for follow‑ups in seconds (default 900–7200).
 
@@ -138,14 +138,14 @@ the model more context from the referenced site.
 
 Arianna purposely waits a little before answering. The delay range depends on
 the chat type and is configurable via the environment variables listed above.
-In group chats, short statements or messages without a question mark are ignored about half of the time (controlled by `SKIP_SHORT_PROB`). When skipped, the bot replies with "Уточните вопрос." Private chats process them by default. Occasionally she will send a brief follow‑up message referencing the earlier conversation.
+In group chats, short statements or messages without a question mark can be skipped if `SKIP_SHORT_PROB` is set above 0. When skipping is enabled, the bot replies with "Уточните вопрос." Private chats process them by default. Occasionally she will send a brief follow‑up message referencing the earlier conversation.
 
 ### Why the bot might not respond
 
 The bot intentionally filters some messages:
 
 - In group chats she replies only when mentioned or when you answer one of her messages.
-- Very short texts or those without a question mark are skipped with probability controlled by `SKIP_SHORT_PROB` (default `0.5` in groups, `0` in private chats). When this happens, the bot replies with "Уточните вопрос." Set `SKIP_SHORT_PROB=0` to disable this in groups as well.
+- Very short texts or those without a question mark can be skipped with probability controlled by `SKIP_SHORT_PROB` (disabled by default). When this happens, the bot replies with "Уточните вопрос." Set `SKIP_SHORT_PROB` to a value greater than 0 (for example `0.5`) to enable this in groups; private chats always use 0.
 - Voice messages that cannot be transcribed are ignored.
 
 ## Deployment

--- a/server_arianna.py
+++ b/server_arianna.py
@@ -273,12 +273,15 @@ async def voice_messages(event):
         logger.info("Skipping voice message: transcription failed")
         return
     text = await append_link_snippets(text)
-    if len(text.split()) < 4 or '?' not in text:
-        skip_prob = SKIP_SHORT_PROB if is_group else 0.0
-        if random.random() < skip_prob:
-            logger.info("Skipping voice message: too short or no question")
-            await event.reply("Уточните вопрос.")
-            return
+    if (
+        is_group
+        and SKIP_SHORT_PROB > 0
+        and (len(text.split()) < 4 or '?' not in text)
+        and random.random() < SKIP_SHORT_PROB
+    ):
+        logger.info("Skipping voice message: too short or no question")
+        await event.reply("Уточните вопрос.")
+        return
     logger.info("Voice message text: %s", text)
     try:
         resp = await engine.ask(thread_key, text, is_group=is_group)
@@ -382,12 +385,15 @@ async def all_messages(event):
         logger.info("Message ignored: bot not mentioned and not a reply")
         return
 
-    if len(text.split()) < 4 or '?' not in text:
-        skip_prob = SKIP_SHORT_PROB if is_group else 0.0
-        if random.random() < skip_prob:
-            logger.info("Skipping message: too short or no question")
-            await event.reply("Уточните вопрос.")
-            return
+    if (
+        is_group
+        and SKIP_SHORT_PROB > 0
+        and (len(text.split()) < 4 or '?' not in text)
+        and random.random() < SKIP_SHORT_PROB
+    ):
+        logger.info("Skipping message: too short or no question")
+        await event.reply("Уточните вопрос.")
+        return
 
     thread_key = user_id if not is_group else str(event.chat_id)
     prompt = await append_link_snippets(text)

--- a/utils/bot_handlers.py
+++ b/utils/bot_handlers.py
@@ -15,8 +15,8 @@ URL_REGEX = re.compile(r"https://\S+")
 URL_FETCH_TIMEOUT = int(os.getenv("URL_FETCH_TIMEOUT", 10))
 
 # Chance to ignore very short or non-question messages.
-# Set to 0 to disable random skipping.
-SKIP_SHORT_PROB = max(0.0, min(1.0, float(os.getenv("SKIP_SHORT_PROB", 0.5))))
+# Set to 0 (the default) to disable random skipping.
+SKIP_SHORT_PROB = max(0.0, min(1.0, float(os.getenv("SKIP_SHORT_PROB", 0.0))))
 
 SendFunc = Callable[[str], Awaitable[None]]
 


### PR DESCRIPTION
## Summary
- Disable random skipping of short or non-question messages by default
- Ensure server skip checks only run when SKIP_SHORT_PROB is set
- Document how to re-enable skipping via `SKIP_SHORT_PROB`

## Testing
- `ruff check .`
- `pytest` *(fails: AttributeError: 'DummyTelegramClient' object has no attribute 'set_bot_commands')*

------
https://chatgpt.com/codex/tasks/task_e_68984a5705cc83299625a3c1f75c160a