### PR TITLE
Use Telethon server as default process

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: uvicorn webhook_server:app --host 0.0.0.0 --port ${PORT:-8000}
-worker: python server_arianna.py
+web: python server_arianna.py
+webhook: uvicorn webhook_server:app --host 0.0.0.0 --port ${PORT:-8000}


### PR DESCRIPTION
## Summary
- run Telethon-based assistant as default `web` process
- move webhook server to separate `webhook` process type

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689847ca8bd88329bd812a0ac22c7e41