### PR TITLE
feat: store messages and snapshots

### DIFF
--- a/server_arianna.py
+++ b/server_arianna.py
@@ -478,7 +478,7 @@ async def main():
     
     # Диагностика сети перед подключением
     try:
-        logger.info(f"Проверка подключения к api.telegram.org...")
+        logger.info("Проверка подключения к api.telegram.org...")
         ip_address = socket.gethostbyname("api.telegram.org")
         logger.info(f"IP адрес api.telegram.org: {ip_address}")
         
@@ -512,18 +512,33 @@ async def main():
         raise SystemExit(f"Не удалось подключиться: {e}")
     me = await client.get_me()
     if BOT_TOKEN or getattr(me, "bot", False):
-        await client.set_bot_commands(
-            [
-                BotCommand(SHORT_COMMANDS[SEARCH_CMD].lstrip("/"), "Semantic search documents"),
-                BotCommand(SHORT_COMMANDS[INDEX_CMD].lstrip("/"), "Index documents"),
-                BotCommand(SHORT_COMMANDS[DEEPSEEK_CMD].lstrip("/"), "Ask DeepSeek"),
-                BotCommand(SHORT_COMMANDS[VOICE_ON_CMD].lstrip("/"), "Enable voice responses"),
-                BotCommand(SHORT_COMMANDS[VOICE_OFF_CMD].lstrip("/"), "Disable voice responses"),
-                BotCommand(SHORT_COMMANDS[HELP_CMD].lstrip("/"), "Show help"),
-                BotCommand(SHORT_COMMANDS[MENU_CMD].lstrip("/"), "Show command menu"),
-            ],
-            scope=BotCommandScopeDefault(),
-        )
+        if hasattr(client, "set_bot_commands"):
+            await client.set_bot_commands(
+                [
+                    BotCommand(
+                        SHORT_COMMANDS[SEARCH_CMD].lstrip("/"), "Semantic search documents"
+                    ),
+                    BotCommand(
+                        SHORT_COMMANDS[INDEX_CMD].lstrip("/"), "Index documents"
+                    ),
+                    BotCommand(
+                        SHORT_COMMANDS[DEEPSEEK_CMD].lstrip("/"), "Ask DeepSeek"
+                    ),
+                    BotCommand(
+                        SHORT_COMMANDS[VOICE_ON_CMD].lstrip("/"), "Enable voice responses"
+                    ),
+                    BotCommand(
+                        SHORT_COMMANDS[VOICE_OFF_CMD].lstrip("/"), "Disable voice responses"
+                    ),
+                    BotCommand(
+                        SHORT_COMMANDS[HELP_CMD].lstrip("/"), "Show help"
+                    ),
+                    BotCommand(
+                        SHORT_COMMANDS[MENU_CMD].lstrip("/"), "Show command menu"
+                    ),
+                ],
+                scope=BotCommandScopeDefault(),
+            )
     BOT_USERNAME = (me.username or "").lower()
     BOT_ID = me.id
     try:

--- a/tests/test_message_snapshot_store.py
+++ b/tests/test_message_snapshot_store.py
@@ -1,0 +1,36 @@
+import datetime
+from utils.thread_store_sqlite import (
+    save_message,
+    get_messages_by_date,
+    search_messages_by_embedding,
+    save_snapshot,
+    get_snapshots_by_date,
+)
+
+
+def epoch(date_str: str) -> int:
+    return int(datetime.datetime.strptime(date_str, "%Y-%m-%d").timestamp())
+
+
+def test_message_store_and_query(tmp_path):
+    db = tmp_path / "threads.sqlite"
+    save_message("t1", "user", "hello", [1.0, 0.0], created_at=epoch("2024-01-01"), db_path=str(db))
+    save_message("t1", "assistant", "world", [0.0, 1.0], created_at=epoch("2024-01-01"), db_path=str(db))
+    save_message("t2", "user", "later", [0.5, 0.5], created_at=epoch("2024-01-02"), db_path=str(db))
+
+    day_msgs = get_messages_by_date("2024-01-01", db_path=str(db))
+    assert len(day_msgs) == 2
+    assert day_msgs[0]["content"] == "hello"
+
+    res = search_messages_by_embedding([1.0, 0.0], top_k=1, db_path=str(db))
+    assert res[0]["content"] == "hello"
+
+
+def test_snapshot_store_and_query(tmp_path):
+    db = tmp_path / "threads.sqlite"
+    save_snapshot("2024-01-01", "snapshot1", created_at=epoch("2024-01-01"), db_path=str(db))
+    save_snapshot("2024-01-02", "snapshot2", created_at=epoch("2024-01-02"), db_path=str(db))
+
+    snaps = get_snapshots_by_date("2024-01-01", db_path=str(db))
+    assert len(snaps) == 1
+    assert snaps[0]["summary"] == "snapshot1"


### PR DESCRIPTION
## Summary
- add SQLite tables for messages and daily snapshots
- log user and assistant messages with embeddings
- search messages by date or semantic similarity
- guard bot command registration for clients lacking that API

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f7af12f988329853d918873275b41